### PR TITLE
fix(security): harden Electron webPreferences, CSP, and dynamic code execution

### DIFF
--- a/src/botGuardScript.js
+++ b/src/botGuardScript.js
@@ -45,6 +45,16 @@ export default async function (videoId, context) {
     interpreterUrl = `https:${interpreterUrl}`
   }
 
+  // Validate the interpreter URL points to a known Google domain
+  const interpreterHost = new URL(interpreterUrl).hostname
+  if (!interpreterHost.endsWith('.google.com') &&
+      !interpreterHost.endsWith('.googleapis.com') &&
+      !interpreterHost.endsWith('.youtube.com') &&
+      !interpreterHost.endsWith('.gstatic.com') &&
+      !interpreterHost.endsWith('.googlevideo.com')) {
+    throw new Error(`Untrusted interpreter host: ${interpreterHost}`)
+  }
+
   const bgScriptResponse = await fetch(interpreterUrl)
   const interpreterJavascript = await bgScriptResponse.text()
 

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -436,6 +436,10 @@ function runApp() {
           }
 
           if (pathname.endsWith('.html')) {
+            // unsafe-eval: required by sigFrame (YouTube cipher decryption via new Function())
+            //   and BotGuard interpreter execution — both run in sandboxed contexts
+            // unsafe-inline (script): required by Vue runtime template compilation
+            // unsafe-inline (style): required by Vue dynamic style bindings (:style="...")
             headers['Content-Security-Policy'] = [
               'default-src \'self\' app:',
               'script-src \'self\' app: \'unsafe-inline\' \'unsafe-eval\'',
@@ -446,6 +450,8 @@ function runApp() {
               'font-src \'self\' app:',
               'frame-src data: blob:',
               'worker-src blob:',
+              'object-src \'none\'',
+              'base-uri \'self\'',
             ].join('; ')
           }
 
@@ -1019,6 +1025,12 @@ function runApp() {
       autoHideMenuBar: true,
       // useContentSize: true,
       webPreferences: {
+        nodeIntegration: false,
+        contextIsolation: true,
+        // sandbox: true would block the preload from importing electron/renderer
+        // (contextBridge, ipcRenderer, webFrame), breaking all IPC communication.
+        // webSecurity: false is inherited from upstream — required for cross-origin
+        // YouTube API requests made directly from the renderer.
         webSecurity: false,
         backgroundThrottling: false,
         preload: process.env.NODE_ENV === 'development'

--- a/src/renderer/sigFrameScript.js
+++ b/src/renderer/sigFrameScript.js
@@ -1,6 +1,11 @@
 // This is injected into the sigFrame iframe
 // See index.ejs and webpack.renderer.config.js
 window.addEventListener('message', (event) => {
+  // Only accept messages from the parent window (the renderer)
+  if (event.source !== window.parent) {
+    return
+  }
+
   const data = JSON.parse(event.data)
 
   try {


### PR DESCRIPTION
## Summary
- Explicitly set `nodeIntegration: false` and `contextIsolation: true` in BrowserWindow webPreferences (were already implicit defaults but not declared)
- Add `object-src 'none'` and `base-uri 'self'` to CSP headers to block plugin/object embeds and base tag hijacking
- Document why `unsafe-eval`, `unsafe-inline`, `webSecurity: false`, and `sandbox` cannot be changed (YouTube cipher/BotGuard/Vue requirements)
- Add `event.source !== window.parent` origin validation to sigFrame postMessage handler
- Add Google domain allowlist validation for BotGuard interpreter URL before fetch+execute

## Test plan
- [ ] Video playback works (sigFrame cipher decryption still functions)
- [ ] Protected content loads (BotGuard/PoToken generation works)
- [ ] Video descriptions render correctly (CSP doesn't block rendering)
- [ ] All IPC communication works (settings, history, playlists, tabs)

Closes #31, #32, #33