### PR TITLE
ci(deps): self-healing + auto-merge for Dependabot npm PRs

### DIFF
--- a/.github/workflows/dependabot-gha-automerge.yml
+++ b/.github/workflows/dependabot-gha-automerge.yml
@@ -26,7 +26,7 @@ jobs:
           # Fail safe: only auto-merge if every changed file is under .github/
           FILES=$(gh pr view "${{ github.event.pull_request.number }}" \
             --repo "${{ github.repository }}" \
-            --json files --jq -r '.files[].path')
+            --json files --jq '.files[].path')
           NON_GHA=$(echo "$FILES" | grep -v '^\.github/' || true)
           if [ -z "$NON_GHA" ]; then
             echo "safe=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/dependabot-npm-automerge.yml
+++ b/.github/workflows/dependabot-npm-automerge.yml
@@ -1,0 +1,152 @@
+name: Auto-heal and merge Dependabot npm PRs
+
+# Dependabot cannot recompute this flake's fetchYarnDeps hash, so every npm PR
+# fails Nix Build and never merges. This workflow heals the hash on the PR
+# branch, proves the build is green, and auto-merges patch/minor updates.
+# Major updates are healed (so they are green) but left for manual review.
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number to heal (manual run; does not auto-merge)"
+        required: true
+
+permissions: {}
+
+jobs:
+  autoheal:
+    # npm/yarn Dependabot PRs only, or a manual dispatch for testing.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.actor == 'dependabot[bot]' &&
+       startsWith(github.head_ref, 'dependabot/npm_and_yarn/'))
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Resolve PR number and head ref
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_PR: ${{ github.event.inputs.pr }}
+          EVENT_PR: ${{ github.event.pull_request.number }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            NUM="$INPUT_PR"
+          else
+            NUM="$EVENT_PR"
+          fi
+          HEAD=$(gh pr view "$NUM" --repo "$REPO" --json headRefName --jq '.headRefName')
+          echo "number=$NUM" >> "$GITHUB_OUTPUT"
+          echo "head=$HEAD" >> "$GITHUB_OUTPUT"
+
+      - name: Get Dependabot metadata
+        id: meta
+        if: github.event_name == 'pull_request'
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pr.outputs.head }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: true
+          fetch-depth: 0
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Recompute fetchYarnDeps hash and verify build
+        id: heal
+        run: |
+          FAKE="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+          sed -i "s|hash = \"sha256-[^\"]*\"|hash = \"$FAKE\"|" flake.nix
+          REAL=$(nix build .#default --no-link 2>&1 | grep -oE 'got: *sha256-[A-Za-z0-9+/=]+' | awk '{print $NF}' || true)
+          if [ -z "$REAL" ]; then
+            # No mismatch surfaced: restore and test the unmodified build.
+            git checkout flake.nix
+          else
+            sed -i "s|hash = \"$FAKE\"|hash = \"$REAL\"|" flake.nix
+          fi
+          if git diff --quiet flake.nix; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+          # Ground truth: does the (healed) tree build end to end?
+          if nix build .#default --no-link --print-build-logs; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit healed hash to the PR branch
+        if: steps.heal.outputs.changed == 'true' && steps.heal.outputs.ok == 'true'
+        env:
+          HEAD: ${{ steps.pr.outputs.head }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add flake.nix
+          git commit -m "build(flake): recompute fetchYarnDeps hash for $HEAD"
+          git push origin "HEAD:$HEAD"
+
+      - name: Flag and fail when the build cannot be made green
+        if: steps.heal.outputs.ok != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          NUM: ${{ steps.pr.outputs.number }}
+        run: |
+          gh pr comment "$NUM" --repo "$REPO" \
+            --body "Auto-heal recomputed the fetchYarnDeps hash but \`nix build .#default\` still fails. This update needs manual investigation before it can merge."
+          exit 1
+
+      - name: Auto-merge patch and minor updates
+        if: >-
+          github.event_name == 'pull_request' &&
+          steps.heal.outputs.ok == 'true' &&
+          steps.meta.outputs.update-type != 'version-update:semver-major'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          NUM: ${{ steps.pr.outputs.number }}
+          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+        run: |
+          gh pr review "$NUM" --repo "$REPO" --approve \
+            --body "Auto-approved: fetchYarnDeps hash healed and nix build passes ($UPDATE_TYPE)."
+          # GitHub needs a moment to recompute mergeability after the push.
+          merged=false
+          for _ in 1 2 3 4 5 6; do
+            if gh pr merge "$NUM" --repo "$REPO" --squash; then
+              merged=true
+              break
+            fi
+            sleep 10
+          done
+          if [ "$merged" != true ]; then
+            gh pr merge "$NUM" --repo "$REPO" --auto --squash
+          fi
+
+      - name: Leave major updates for manual review
+        if: >-
+          github.event_name == 'pull_request' &&
+          steps.heal.outputs.ok == 'true' &&
+          steps.meta.outputs.update-type == 'version-update:semver-major'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          NUM: ${{ steps.pr.outputs.number }}
+        run: |
+          gh pr comment "$NUM" --repo "$REPO" \
+            --body "fetchYarnDeps hash healed and nix build passes. This is a **major** version update, so it is left for manual review and merge."

--- a/.github/workflows/security-alert-watch.yml
+++ b/.github/workflows/security-alert-watch.yml
@@ -1,0 +1,58 @@
+name: Watch open Dependabot alerts
+
+# Safety net for alerts that automation cannot fix on its own, e.g. transitive
+# deps pinned below the patched version (Dependabot opens no PR for those, so
+# they would otherwise sit open silently). Surfaces them in one tracking issue.
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: read
+      issues: write
+
+    steps:
+      - name: Surface open alerts into a tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TITLE: "Open Dependabot alerts need attention"
+        run: |
+          # jq expressions and literal markdown backticks are intentionally single-quoted.
+          # shellcheck disable=SC2016
+          ALERTS=$(gh api "repos/$REPO/dependabot/alerts?state=open&per_page=100" \
+            --jq '.[] | "- #\(.number) **\(.security_advisory.severity)** `\(.dependency.package.name)` (\(.dependency.scope)) in `\(.dependency.manifest_path)` -> \(.security_vulnerability.first_patched_version.identifier // "no patched version")"' || true)
+
+          EXISTING=$(gh issue list --repo "$REPO" --state open --limit 100 \
+            --json number,title --jq ".[] | select(.title==\"$TITLE\") | .number" | head -n1)
+
+          if [ -z "$ALERTS" ]; then
+            if [ -n "$EXISTING" ]; then
+              gh issue close "$EXISTING" --repo "$REPO" \
+                --comment "All Dependabot alerts are resolved. Closing automatically."
+            fi
+            echo "No open Dependabot alerts."
+            exit 0
+          fi
+
+          # shellcheck disable=SC2016
+          BODY=$(printf 'These Dependabot alerts are still open. Patch/minor cases auto-merge via the npm auto-heal workflow; anything listed here likely needs a manual fix (commonly a transitive dependency pinned below the patched version, which Dependabot cannot bump on its own — add a `resolutions` entry in `package.json`).\n\n%s\n\n_Updated %s UTC by the alert-watch workflow._' \
+            "$ALERTS" "$(date -u '+%Y-%m-%d %H:%M')")
+
+          if [ -n "$EXISTING" ]; then
+            gh issue edit "$EXISTING" --repo "$REPO" --body "$BODY"
+            echo "Updated tracking issue #$EXISTING."
+          else
+            gh issue create --repo "$REPO" --title "$TITLE" --body "$BODY" \
+              --label "PR: dependencies" 2>/dev/null \
+              || gh issue create --repo "$REPO" --title "$TITLE" --body "$BODY"
+            echo "Opened tracking issue."
+          fi


### PR DESCRIPTION
## Why

Follow-up to #127. The 5 alerts are fixed, but the *reason updates kept breaking* was structural: Dependabot can't recompute this flake's `fetchYarnDeps` hash, so every npm PR fails `Nix Build`, never merges, and the queue rots. This makes the update flow self-sustaining.

## What

- **`dependabot-npm-automerge.yml`** (the core fix): on each `dependabot/npm_and_yarn/*` PR it recomputes the `fetchYarnDeps` hash, runs `nix build .#default` to prove the result is green, pushes the healed hash to the PR branch, then:
  - **patch/minor** → auto-approve + squash-merge
  - **major** → healed (so it's green) but left for manual review, with a comment
  - **build still fails after healing** → comments and fails, so it can't silently merge breakage

  Uses `pull_request` + an elevated `permissions:` block (same pattern as the existing gha-automerge), not `pull_request_target`, so it avoids the high-sev untrusted-checkout pattern. The `GITHUB_TOKEN` is never exposed to the Nix build. All `${{ }}` values are passed through `env:` rather than interpolated into shell.

- **`security-alert-watch.yml`**: a daily net that lists any open Dependabot alert in one auto-updating tracking issue. This catches the cases automation *can't* fix, e.g. transitive deps pinned below the patched version that Dependabot won't open a PR for (the recent `qs`/`uuid`), so they never sit open silently again.

- **`dependabot-gha-automerge.yml`**: fixed a malformed `gh ... --jq -r` invocation.

Validated with `actionlint` + `shellcheck` (clean for all three).

## Note

The end-to-end auto-merge path can only be fully exercised by a real Dependabot npm PR (the hash-recompute logic itself is the same one proven green in #127 and by a local full `nix build`). The first Dependabot npm PR after this merges will be the live test.
