### PR TITLE
ci(deps): make batch-deps re-runnable

### DIFF
--- a/.github/workflows/batch-deps.yml
+++ b/.github/workflows/batch-deps.yml
@@ -68,16 +68,23 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
           BRANCH="batch-deps/$(date +%Y-%m-%d)"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$BRANCH"
+          # -B and force-push make re-runs idempotent (e.g. a retry after a
+          # mid-run failure) instead of colliding with a stale same-day branch.
+          git checkout -B "$BRANCH"
           git add package.json yarn.lock flake.nix
           git commit -m "chore(deps): weekly batch dependency upgrade $(date +%Y-%m-%d)"
-          git push origin "$BRANCH"
-          gh pr create \
-            --title "chore(deps): weekly batch dependency upgrade $(date +%Y-%m-%d)" \
-            --body "Automated weekly batch of compatible dependency upgrades via 'yarn upgrade'. All bumps respect existing semver ranges in package.json. The flake.nix fetchYarnDeps hash is recomputed when yarn.lock changes. Electron and other major-version bumps are handled separately by Dependabot. Review the yarn.lock diff for specifics; CI must pass before merging." \
-            --base development \
-            --label "PR: dependencies"
+          git push -f origin "$BRANCH"
+          if gh pr view "$BRANCH" --repo "$REPO" --json number --jq '.number' >/dev/null 2>&1; then
+            echo "A PR already exists for $BRANCH; the force-push updated it."
+          else
+            gh pr create \
+              --title "chore(deps): weekly batch dependency upgrade $(date +%Y-%m-%d)" \
+              --body "Automated weekly batch of compatible dependency upgrades via 'yarn upgrade'. All bumps respect existing semver ranges in package.json. The flake.nix fetchYarnDeps hash is recomputed when yarn.lock changes. Electron and other major-version bumps are handled separately by Dependabot. Review the yarn.lock diff for specifics; CI must pass before merging." \
+              --base development \
+              --label "PR: dependencies"
+          fi


### PR DESCRIPTION
Hardening found while live-testing batch-deps: the dated branch (`batch-deps/YYYY-MM-DD`) collided on a same-day re-run (the first run pushed the branch then failed at PR-create, so the retry's push was rejected non-fast-forward). Now uses `checkout -B` + `git push -f` and skips `gh pr create` if a PR already exists, so retries are idempotent.