### PR TITLE
fix(tabs): handle ctrl/shift+click on links, clear address bar on new tab

### DIFF
--- a/DESIGN-TABS.md
+++ b/DESIGN-TABS.md
@@ -93,7 +93,7 @@ Replace `<RouterView>` with tab-aware content area using `<keep-alive>`:
 Navigation behavior:
 - **Normal click**: Navigate within active tab (push to tab's history stack)
 - **Middle-click / Ctrl+click**: Open in new background tab
-- **Shift+click**: Open in new foreground tab
+- **Shift+click**: Open in a new window containing just that page (browser convention)
 
 Composable `useTabNavigation()`:
 ```js

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -251,7 +251,16 @@ onMounted(async () => {
 
     // Initialize tabs before dataReady so the UI renders with tabs ready
     if (enableTabs.value) {
-      const restored = await store.dispatch('tabs/restoreTabs')
+      // A window opened with an explicit deep-link (e.g. Shift+click "open in
+      // new window") arrives with a non-root startup route. It should show just
+      // that page as a fresh tab rather than cloning the previous session, and
+      // must not persist over the saved session. (#116)
+      const isDeepLinkStartup = route.path !== '/'
+      if (isDeepLinkStartup) {
+        store.commit('tabs/setEphemeral', true)
+      }
+
+      const restored = !isDeepLinkStartup && await store.dispatch('tabs/restoreTabs')
       if (restored) {
         const activeTab = store.getters['tabs/getActiveTab']
         if (activeTab) {
@@ -579,11 +588,56 @@ function isExternalLink(event) {
 }
 
 /**
+ * Resolves the FreeTube route from an internal link the event originated on
+ * (the target may be a child element of the `<a>`). Returns null for external
+ * links or non-link targets.
+ * @param {EventTarget} target
+ * @returns {{ path: string, query: object } | null}
+ */
+function parseInternalLinkRoute(target) {
+  const link = target.closest?.('a[href]')
+  if (!link) return null
+
+  const href = link.href
+  if (!href || !href.startsWith(window.location.origin)) return null
+
+  const url = new URL(href)
+  // Extract the route path from the hash (format: #/path?query)
+  const hashPath = url.hash.slice(1) // remove #
+  const [path, queryString] = hashPath.split('?')
+  const query = queryString ? Object.fromEntries(new URLSearchParams(queryString)) : {}
+  return { path, query }
+}
+
+/**
  * @param {PointerEvent} event
  */
 function handleClick(event) {
   if (isExternalLink(event)) {
     handleLinkClick(event)
+    return
+  }
+
+  // Tab-aware modifier clicks on internal links. Vue Router's <router-link>
+  // ignores modified clicks, so without this they fall through to the main
+  // process window-open handler and spawn a new window instead of a new tab.
+  // (#112, #113, #116)
+  if (!enableTabs.value) return
+
+  const ctrlOrCmd = (process.platform !== 'darwin' && event.ctrlKey) ||
+    (process.platform === 'darwin' && event.metaKey)
+  if (!ctrlOrCmd && !event.shiftKey) return
+
+  const route = parseInternalLinkRoute(event.target)
+  if (!route) return
+
+  event.preventDefault()
+  if (ctrlOrCmd) {
+    // Ctrl/Cmd+click -> new background tab
+    openInternalPath({ ...route, doCreateNewTab: true })
+  } else {
+    // Shift+click -> new window containing just this page
+    openInternalPath({ ...route, doCreateNewWindow: true })
   }
 }
 
@@ -598,19 +652,16 @@ function handleAuxClick(event) {
 
   if (isExternalLink(event)) {
     handleLinkClick(event)
-  } else if (enableTabs.value && event.target.closest('a[href]')) {
-    // Middle-click on internal link opens in new tab
-    const link = event.target.closest('a[href]')
-    const href = link.href
-    if (href && href.startsWith(window.location.origin)) {
-      event.preventDefault()
-      const url = new URL(href)
-      // Extract the route path from the hash (format: #/path?query)
-      const hashPath = url.hash.slice(1) // remove #
-      const [path, queryString] = hashPath.split('?')
-      const query = queryString ? Object.fromEntries(new URLSearchParams(queryString)) : {}
-      openInternalPath({ path, query, doCreateNewTab: true })
-    }
+    return
+  }
+
+  // Middle-click on internal link opens in a new background tab
+  if (!enableTabs.value) return
+
+  const route = parseInternalLinkRoute(event.target)
+  if (route) {
+    event.preventDefault()
+    openInternalPath({ ...route, doCreateNewTab: true })
   }
 }
 

--- a/src/renderer/components/TopNav/TopNav.vue
+++ b/src/renderer/components/TopNav/TopNav.vue
@@ -566,6 +566,26 @@ function updateSearchInputText(text) {
   searchInput.value?.setText(text)
 }
 
+// Keep the address bar in sync with the active tab: clear it on a fresh tab,
+// show the query when switching to a search tab. Watches the tab id (not the
+// route) so it only fires on tab switches / new tabs, never mid-typing. (#111)
+const activeTabId = computed(() => store.getters.getEnableTabs ? store.getters['tabs/getActiveTabId'] : null)
+watch(activeTabId, () => {
+  const path = store.getters['tabs/getActiveTab']?.route?.path ?? ''
+  const searchPrefix = '/search/'
+  if (!path.startsWith(searchPrefix)) {
+    updateSearchInputText('')
+    return
+  }
+  let query = path.slice(searchPrefix.length)
+  try {
+    query = decodeURIComponent(query)
+  } catch {
+    // keep the raw value if it isn't valid percent-encoding
+  }
+  updateSearchInputText(query)
+})
+
 /**
  * @param {string} query
  */

--- a/src/renderer/store/modules/tabs.js
+++ b/src/renderer/store/modules/tabs.js
@@ -58,6 +58,9 @@ const state = {
   closedTabsHistory: [],
   tabSwitchInProgress: false,
   tabSwitchNavCount: 0,
+  // Ephemeral windows (e.g. Shift+click "open in new window") neither restore
+  // nor persist the shared tab session, so they can't clobber it. (#116)
+  ephemeral: false,
 }
 
 const getters = {
@@ -105,6 +108,10 @@ const mutations = {
 
   setActiveTabId(state, tabId) {
     state.activeTabId = tabId
+  },
+
+  setEphemeral(state, val) {
+    state.ephemeral = val
   },
 
   addTab(state, { tab, index }) {
@@ -247,7 +254,7 @@ function iconFromPath(path) {
 
 const actions = {
   persistTabs({ state, dispatch }) {
-    if (typeof DBTabsHandlers === 'undefined') return
+    if (typeof DBTabsHandlers === 'undefined' || state.ephemeral) return
 
     clearTimeout(persistDebounceTimer)
     persistDebounceTimer = setTimeout(() => {
@@ -285,7 +292,7 @@ const actions = {
 
   /** Immediately persist tabs (for beforeunload). */
   async persistTabsImmediate({ state }) {
-    if (typeof DBTabsHandlers === 'undefined') return
+    if (typeof DBTabsHandlers === 'undefined' || state.ephemeral) return
     clearTimeout(persistDebounceTimer)
     if (persistBackoffTimer !== null) {
       clearTimeout(persistBackoffTimer)


### PR DESCRIPTION
Addresses the modifier-click + tab-navigation bug cluster reported by @raindropsfromsky. #113 was already closed as a duplicate of #112.

## Root cause
Ctrl/Shift+click on internal links was never handled by the tab layer. Vue Router's `<router-link>` ignores modifier clicks, so they fell through to the main-process window-open handler and spawned a new window. Only middle-click had been wired up to open a tab.

## Changes
- **Ctrl/Cmd+click** on an internal link opens a new background tab (the same path middle-click already used). macOS uses Cmd, leaving Ctrl+click as the secondary click. (#112, #113)
- **Shift+click** opens a new window containing just that page. Deep-linked windows are now ephemeral: they neither restore nor persist the shared tab session, so they no longer clone the previous session or overwrite it. (#116)
- **Address bar** syncs to the active tab, clearing on a fresh tab and showing the query on a search tab. (#111)
- Factored a shared `parseInternalLinkRoute` helper used by the middle/ctrl/shift click paths; updated `DESIGN-TABS.md`.

## Verification
ESLint clean. Each modifier-click path traced and store getters/mutations confirmed. Not runtime click-tested (GUI interaction).

Fixes #111
Fixes #112
Fixes #116
